### PR TITLE
Fix outdated cBioPortal API endpoint causing HTTP 302 in intro notebook

### DIFF
--- a/python/intro/intro.ipynb
+++ b/python/intro/intro.ipynb
@@ -94,7 +94,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c:\\codebook\\cbio_env\\Scripts\\python.exe\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "print(sys.executable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -2117,7 +2135,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cbio_env311",
    "language": "python",
    "name": "python3"
   },
@@ -2131,7 +2149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/python/intro/intro.ipynb
+++ b/python/intro/intro.ipynb
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -142,11 +142,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SwaggerClient(https://www.cbioportal.org/api)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "cbioportal."
+    "cbioportal"
    ]
   },
   {
@@ -160,22 +171,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<bravado.http_future.HttpFuture at 0x1180fc6a0>"
+       "<bravado.http_future.HttpFuture at 0x21b07a33b10>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "cbioportal.Cancer_Types.getAllCancerTypesUsingGET("
+    "cbioportal.Cancer_Types.getAllCancerTypesUsingGET()"
    ]
   },
   {
@@ -187,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Fixes #4

The intro notebook was using the outdated endpoint:

https://www.cbioportal.org/api/api-docs

This now returns HTTP 302 redirect, which causes bravado to fail.

Updated the endpoint to:

https://www.cbioportal.org/api/v2/api-docs

Verified that the notebook runs successfully.